### PR TITLE
Allow persisting URL params for shortented URLs

### DIFF
--- a/app/controllers/shortener/shortened_urls_controller.rb
+++ b/app/controllers/shortener/shortened_urls_controller.rb
@@ -1,5 +1,4 @@
 class Shortener::ShortenedUrlsController < ActionController::Base
-
   # find the real link for the shortened link key and redirect
   def show
     # only use the leading valid characters
@@ -13,17 +12,30 @@ class Shortener::ShortenedUrlsController < ActionController::Base
       # this is the place to enhance the metrics captured
       # for the system. You could log the request origin
       # browser type, ip address etc.
-      #Thread.new do
+      # Thread.new do
       #  sl.increment!(:use_count)
       #  ActiveRecord::Base.connection.close
-      #end
+      # end
       # do a 301 redirect to the destination url
-      redirect_to sl.url, :status => :moved_permanently
+      redirect_to add_params(
+        sl.url,
+        request.params.except(:id, :a, :plea, :action, :controller)
+      ), status: :moved_permanently
     else
       # if we don't find the shortened link, redirect to the root
       # make this configurable in future versions
-      redirect_to '/'
+      redirect_to "/"
     end
   end
 
+  private
+
+  # Persist the URL params appended to the shortened URL upon redirect
+  def add_params(url, url_params = {})
+    uri = URI(url)
+    url_params = Hash[URI.decode_www_form(uri.query || "")].merge(url_params)
+    uri.query = URI.encode_www_form(url_params)
+
+    uri.to_s
+  end
 end


### PR DESCRIPTION
<h2>Background</h2>

We currently don't allow appending custom URL parameters to our unique tracking links, which means that schools cannot use our unique tracking links with specific google analytics features, such as [UTM codes](https://en.wikipedia.org/wiki/UTM_parameters).

Urchin Tracking Module (UTM) parameters are five variants of URL parameters used by marketers to track the effectiveness of online marketing campaigns across traffic sources and publishing media. They were introduced by Google Analytics' predecessor Urchin and, consequently, are supported out-of-the-box by Google Analytics. 

The UTM parameters in a URL identify the campaign that refers traffic to a specific website,[1] and attributes the browser's website session and the sessions after that until the campaign attribution window expires to it. The parameters can be parsed by analytics tools and used to populate reports.[2] Example URL, UTM parameters highlighted, after the question mark (?):

```
https://www.example.com/page?utm_content=buffercf3b2&utm_medium=social&utm_source=facebook.com&utm_campaign=buffer
```


<h2>Solution</h2>

Allow persisting any appended URL parameters, with the exception of parameters we are already adding such as `a`, and also make sure to exclude Rails specific parameters such as `controller, action`.

<h2>Steps to test</h2>

- git clone this repository locally by changing the parameter from `git` to `path` and pointing to the directory on your 
machine where you cloned this repo `gem "shortener", path: "local/path/to/shortener"`
- checkout this branch - `git checkout cw-allow-persisting-url-params`
- Update the Gemfile in the givecampus repository to point to this local repository
- Generate a unique tracking link for a campaign/giving form
- Copy the generated unique tracking link URL into the browser and append the following URL parameters
  - `utm_medium=social&utm_source=facebook&utm_campaign=buffer&random_param=true`
- verify that when you are redirected to the campaign/giving form that the URL parameters are persisted on the redirect