### PR TITLE
Only allow supported UTM parameters to be passed in

### DIFF
--- a/app/controllers/shortener/shortened_urls_controller.rb
+++ b/app/controllers/shortener/shortened_urls_controller.rb
@@ -8,22 +8,13 @@ class Shortener::ShortenedUrlsController < ActionController::Base
     sl = ::Shortener::ShortenedUrl.find_by_unique_key(token)
 
     if sl
-      # don't want to wait for the increment to happen, make it snappy!
-      # this is the place to enhance the metrics captured
-      # for the system. You could log the request origin
-      # browser type, ip address etc.
-      # Thread.new do
-      #  sl.increment!(:use_count)
-      #  ActiveRecord::Base.connection.close
-      # end
-      # do a 301 redirect to the destination url
+      # Perform a 301 redirect to the destination url, while persisting allowed URL parameters
       redirect_to add_params(
         sl.url,
-        request.params.except(:id, :a, :plea, :action, :controller)
+        request.params.slice(*allowed_params)
       ), status: :moved_permanently
     else
-      # if we don't find the shortened link, redirect to the root
-      # make this configurable in future versions
+      # If we don't find the shortened link, redirect to the root
       redirect_to "/"
     end
   end
@@ -37,5 +28,9 @@ class Shortener::ShortenedUrlsController < ActionController::Base
     uri.query = URI.encode_www_form(url_params)
 
     uri.to_s
+  end
+
+  def allowed_params
+    [:utm_source, :utm_medium, :utm_campaign, :utm_term, :utm_content]
   end
 end


### PR DESCRIPTION
## Background
Previously we made a change that allowed you to append any custom query string parameter onto the URL, as long as it wasn't one that we were currently using. This breaks down when we need to carry the custom query string parameters throughout the donation flow, which can include a lot more parameters that we would need to filter out. This would actually be more work than is necessary, instead of just limiting it to the supported UTM parameters in the first place.

## Solution

Previously we allowed any custom query string parameter to be appended to the shortened URL, which would allow more than we need for this specific use-case. With this change you can add supported UTM parameters (such as `utm_source`, `utm_medium`, and `utm_campaign`) to a URL to capture reporting data about the referring campaign. For example, the following link would allow you to identify the traffic to example.com that came from a particular email newsletter, as part of a particular campaign:

```html
http://localhost:3000/3b32rj?a=1234&utm_source=facebook&utm_medium=cpc&utm_campaign=giving%20day&utm_term=givingday+2020&utm_content=textlink

```

The following UTM parameters are supported:

- **`utm_source`** (Use `utm_source` to identify a search engine, newsletter name, or other source.)

  Example: `google`

- **`utm_medium`** (Use `utm_medium` to identify a medium such as `email` or `cost-per- click`).

  Example: `cpc`
 
- **`utm_campaign`** (Used for keyword analysis. Use `utm_campaign` to identify a specific product promotion or strategic campaign.)

  Example: `utm_campaign=spring_sale`
 
- **`utm_term`** (Used for paid search. Use `utm_term` to note the keywords for this ad.)

  Example: `running+shoes`

- **`utm_content`** (Used for A/B testing and content-targeted ads. Use `utm_content` to differentiate ads or links that point to the same URL.)

  Examples: `logolink` or `textlink`

Any other parameters other than the ones we pass through already, `a`, and `plea`, will not be allowed and will be stripped from the URL, before the redirect back to GiveCampus.

This will prevent the need to continue to exclude parameters from within the application. The allowed (whitelisted) parameters are fewer than the blacklisted parameters would be.


### Examples / References
- [https://agencyanalytics.com/blog/utm-tracking](https://agencyanalytics.com/blog/utm-tracking)
- [https://neilpatel.com/blog/the-ultimate-guide-to-using-utm-parameters/](https://neilpatel.com/blog/the-ultimate-guide-to-using-utm-parameters/)
- [https://ga-dev-tools.appspot.com/campaign-url-builde](https://ga-dev-tools.appspot.com/campaign-url-builde)
- [https://support.google.com/analytics/answer/1033867?hl=en](https://support.google.com/analytics/answer/1033867?hl=en)


## Steps to Test:

- Update the branch for the `shortener` gem within the `givecampus` git repository
 ```ruby
   gem "shortener", git: "https://github.com/givecampus/shortener", branch: "cw-limit-custom-params-to-utm-params"
  ```

```bash
  bundle update --source shortener
```

- Create a unique tracking link
- Copy the unique tracking link
- Append any of the supported UTM parameters to the URL
- Upon redirecting to the application, the supported UTM parameters should persist
- If you repeat and add any custom URL parameter, it should be discarded upon the redirect