### PR TITLE
Update retry count to 10

### DIFF
--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -66,6 +66,7 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
       self.unique_key = generate_unique_key
       super()
     rescue ActiveRecord::RecordNotUnique, ActiveRecord::StatementInvalid => err
+      logger.info("Shortener gem attempted to generate a unique key and raised the following err: #{err}")
       if (count +=1) < 10
         logger.info("retrying with different unique key")
         retry

--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -66,7 +66,7 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
       self.unique_key = generate_unique_key
       super()
     rescue ActiveRecord::RecordNotUnique, ActiveRecord::StatementInvalid => err
-      if (count +=1) < 5
+      if (count +=1) < 10
         logger.info("retrying with different unique key")
         retry
       else


### PR DESCRIPTION
About 10 times per month, we fail to create sharing links within the platform (e.g., unique tracking links, social sharing button links, personal plea links, etc.) and the page crashes.

We have about 1.7mil of these links within our database, and the generation process is random. While there should be billions of possible combinations for the shortened URL's we're randomly generating, we occasionally run into naming collisions.

Unfortunately, after trying to generate a unique URL 5 times in a row, the code gives up and likely displays a Whoops! page to the user in question.

Retrying this logic isn't resource-intensive, so let's bump the amount of possible retries to significantly reduce the possibility of this edge case in the future.

Marking as Medium priority, since even though this happens rarely, it can still crash the campaign page completely and lead to a school losing out on a $1000 gift.

For Engineering:

We need to update this line within the shortener Ruby project to increase the retry_count to something like 10

We'll then need to update the Gemfile within the givecampus project to reflect our changes.

Example Server Log

https://app.asana.com/0/1172077698943204/1199397100687775