### PR TITLE
Allow all params through shortened url besides a select few

### DIFF
--- a/app/controllers/shortener/shortened_urls_controller.rb
+++ b/app/controllers/shortener/shortened_urls_controller.rb
@@ -11,7 +11,7 @@ class Shortener::ShortenedUrlsController < ActionController::Base
       # Perform a 301 redirect to the destination url, while persisting allowed URL parameters
       redirect_to add_params(
         sl.url,
-        request.params.slice(*allowed_params)
+        request.params.except(:id, :a, :plea, :action, :controller)
       ), status: :moved_permanently
     else
       # If we don't find the shortened link, redirect to the root
@@ -28,9 +28,5 @@ class Shortener::ShortenedUrlsController < ActionController::Base
     uri.query = URI.encode_www_form(url_params)
 
     uri.to_s
-  end
-
-  def allowed_params
-    [:utm_source, :utm_medium, :utm_campaign, :utm_term, :utm_content]
   end
 end


### PR DESCRIPTION
This effectively reverts the changes in this PR: https://github.com/givecampus/shortener/pull/2

**Goal**
We've heard from a couple of partners that autofill and personalization would not be usable if they could not use our tracking links at the same time. In order to encourage the use of personalization to increase conversion and still enable schools to see how their outreach is going, we should allow these two features to work together.

**Current Code Flow**
1. A donor enters a shortened URL like: http://localhost:3000/dl1lzk?a=123
2. We route this to the Shortener::ShortenedUrlsController within the Shotener gem repo
3. We then attempt to find the correct URL based on the id `dl1lzk`
4. If the URL can be found then we redirect the user to that URL and wipe the params passed with the link besides any utm_params

**New Code Flow**
1. A donor enters a shortened URL like: http://localhost:3000/dl1lzk?a=123
2. We route this to the Shortener::ShortenedUrlsController within the Shotener gem repo
3. We then attempt to find the correct URL based on the id `dl1lzk`
4. If the URL can be found then we redirect the user to that URL and pass all params besides [:id, :a, :plea, :action, :controller]

**Testing Gem Change locally**
1. Clone the shortener gem `git clone https://github.com/givecampus/shortener.git`
2. Update GiveCampus gemfile and change:
`gem "shortener", git: "https://github.com/givecampus/shortener"`
to:
`gem "shortener", :path => 'YOUR LOCAL GEM PATH HERE'`
3. Bundle install
4. Test using the link with pass through params: `http://localhost:3000/dl1lzk?a=123&b=456&adid=personalization_token&hide_designation=true`
5. Ensure params are respected.
