### PR TITLE
ROLLBACK within shortener gem to fix PG::InFailedSqlTransaction error

### DIFF
--- a/app/models/shortener/shortened_url.rb
+++ b/app/models/shortener/shortened_url.rb
@@ -53,7 +53,10 @@ class Shortener::ShortenedUrl < ActiveRecord::Base
       super()
     rescue ActiveRecord::RecordNotUnique, ActiveRecord::StatementInvalid => err
       logger.info("Shortener gem attempted to generate a unique key and raised the following err: #{err}")
-      if (count +=1) < 10
+      ActiveRecord::Base.connection.execute 'ROLLBACK'
+      logger.info("Shortener gem ROLLBACK complete")
+
+      if (count += 1) < 10
         logger.info("retrying with different unique key")
         retry
       else


### PR DESCRIPTION
[Asana Task](https://app.asana.com/0/1201157086826331/1201717264810356)

"undefined method `unique_key' for nil:NilClass" pops up in various places every few days: https://my.papertrailapp.com/systems/givecampus/events?q=+undefined+method+%60unique_key%27+

Looking at the errors from [this request](this) what happens is we first get an error for:
`PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "index_shortened_urls_on_unique_key"`

We then retry multiple times and receive this error:
`PG::InFailedSqlTransaction: ERROR: current transaction is aborted, commands ignored until end of transaction block`

Based on this stack overflow article: https://stackoverflow.com/questions/21138207/activerecordstatementinvalid-pg-infailedsqltransaction

It looks like the first failure is causing the others so we may need to manually rollback that transaction and then create again.
