### PR TITLE
Remove unnecessary autoload

### DIFF
--- a/lib/shortener/railtie.rb
+++ b/lib/shortener/railtie.rb
@@ -6,8 +6,5 @@ class Shortener::Railtie < ::Rails::Railtie #:nodoc:
     ActiveSupport.on_load :active_record do
       extend Shortener::ActiveRecordExtension
     end
-    ActiveSupport.on_load :action_view do
-      include Shortener::ShortenerHelper
-    end
   end
 end


### PR DESCRIPTION
This autoload is breaking with the upgrade to rails 7. I've confirmed that this doesn't create any issues in `givecampus`. It looks like the repo that we originally copied this gem from already removed this a few years ago: https://github.com/jpmcgrath/shortener/commit/b17450cb7b5d4d55dccced78bd9297e3439dca59

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205263978024454